### PR TITLE
在 pom.xml中添加parent.relativePath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.2.6.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>


### PR DESCRIPTION
解决构建时报错：
'parent.relativePath' of POM io.renren:renren-generator:1.0.0 (/Users/gcsp/IdeaProjects/gulimall/renren-generator/pom.xml) points at com.atguigu.gulimall:gulimall instead of org.springframework.boot:spring-boot-starter-parent, please verify your project structure